### PR TITLE
Use OpenSSL::Cipher rather than OpenSSL::Cipher::Cipher.

### DIFF
--- a/lib/recaptcha_mailhide/encrypt.rb
+++ b/lib/recaptcha_mailhide/encrypt.rb
@@ -36,7 +36,7 @@ module RecaptchaMailhide
     # Initializes the cipher.
     #
     def self.build_aes
-      aes = OpenSSL::Cipher::Cipher.new("aes-128-cbc")
+      aes = OpenSSL::Cipher.new("aes-128-cbc")
       aes.encrypt
       aes.iv = INITIALIZATION_VECTOR
       aes.padding = 0


### PR DESCRIPTION
OpenSSL::Cipher::Cipher was deprecated with Ruby 1.8.7.

RSpec examples succeeded with Ruby versions 1.8.7-p370, 2.0.0-p598, 2.2.3-p173, 2.3.4-p301, and 2.4.1-p111.